### PR TITLE
add logs viewing over SSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+sdkconfig
+sdkconfig.old

--- a/basic/main/main.c
+++ b/basic/main/main.c
@@ -161,6 +161,10 @@ void app_main()
 	ESP_ERROR_CHECK(http_logging_init( CONFIG_LOG_HTTP_SERVER_URL, write_to_stdout ));
 #endif // CONFIG_ENABLE_HTTP_LOG
 
+#if CONFIG_ENABLE_SSE_SERVER_LOG
+	ESP_ERROR_CHECK(sse_logging_init( CONFIG_LOG_SSE_LISTEN_PORT, write_to_stdout ));
+#endif // CONFIG_ENABLE_SSE_SERVER_LOG
+
 	ESP_LOGI(TAG, "This is info level");
 	ESP_LOGW(TAG, "This is warning level");
 	ESP_LOGE(TAG, "This is error level");

--- a/components/net-logging/CMakeLists.txt
+++ b/components/net-logging/CMakeLists.txt
@@ -1,7 +1,16 @@
-set(component_srcs "net_logging.c" "udp_client.c" "tcp_client.c" "mqtt_pub.c" "http_client.c")
-
-idf_component_register(SRCS "${component_srcs}"
-                       INCLUDE_DIRS "."
-                       REQUIRES esp_http_client
-                       REQUIRES esp_ringbuf
-                       REQUIRES mqtt)
+idf_component_register(
+  SRCS
+    "net_logging.c"
+    "udp_client.c"
+    "tcp_client.c"
+    "mqtt_pub.c"
+    "http_client.c"
+    "sse_server.c"
+  INCLUDE_DIRS "."
+  REQUIRES
+    "esp_http_client"
+    "esp_ringbuf"
+    "mqtt"
+  EMBED_TXTFILES
+    "assets/sse.html"
+  )

--- a/components/net-logging/Kconfig.projbuild
+++ b/components/net-logging/Kconfig.projbuild
@@ -27,6 +27,10 @@ menu "NET Logging"
 			bool "HTTP Logging"
 			help
 				Enable HTTP Logging
+		config ENABLE_SSE_SERVER_LOG
+			bool "SSE Logging"
+			help
+				Enable SSE Logging Server
 	endchoice
 
 	config ESP_WIFI_SSID
@@ -95,6 +99,13 @@ menu "NET Logging"
 		default "http://myhttpserver.local:8000"
 		help
 			URL of the http server to connect to.
+
+	config LOG_SSE_LISTEN_PORT
+		depends on ENABLE_SSE_SERVER_LOG
+		int "Port to bind the SSE server on"
+		default 8080
+		help
+			Port to bind the SSE server on
 
 	config USE_RINGBUFFER
 		bool "Use xRingBuffer as IPC"

--- a/components/net-logging/assets/sse.html
+++ b/components/net-logging/assets/sse.html
@@ -1,0 +1,211 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ESP Logs</title>
+  <style>
+    :root {
+      --bg-color: #222;
+      --text-color: #f0f0f0;
+      --header-color: #3498db;
+    }
+    
+    body {
+      font-family: monospace;
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      margin: 0;
+      padding: 20px;
+      line-height: 1.6;
+    }
+    
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    
+    header {
+      border-bottom: 1px solid #444;
+      padding-bottom: 10px;
+      margin-bottom: 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    
+    h1 {
+      color: var(--header-color);
+      margin: 0;
+    }
+    
+    .controls {
+      display: flex;
+      gap: 10px;
+    }
+    
+    button {
+      background-color: #333;
+      color: var(--text-color);
+      border: 1px solid #555;
+      padding: 5px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+    
+    button:hover {
+      background-color: #444;
+    }
+    
+    #logs {
+      background-color: #111;
+      border-radius: 6px;
+      padding: 10px;
+      height: calc(100vh - 150px);
+      overflow-y: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    
+    .log-line {
+      display: block;
+      padding: 1px 5px;
+      margin-bottom: 2px;
+      border-left: 3px solid #555;
+    }
+    
+    .log-line:hover {
+      background-color: rgba(255, 255, 255, 0.05);
+    }
+    
+    .status {
+      font-size: 0.8em;
+      margin-top: 10px;
+      color: #777;
+    }
+    
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg-color: #f5f5f5;
+        --text-color: #333;
+      }
+      
+      #logs {
+        background-color: #fff;
+        border: 1px solid #ddd;
+      }
+      
+      button {
+        background-color: #e0e0e0;
+        color: #333;
+        border: 1px solid #ccc;
+      }
+      
+      button:hover {
+        background-color: #d0d0d0;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <header>
+      <h1>ESP32 Logs</h1>
+      <div class="controls">
+        <button id="clearBtn">Clear</button>
+        <button id="pauseBtn">Pause</button>
+        <button id="scrollBtn">Auto-scroll</button>
+      </div>
+    </header>
+    
+    <div id="logs"></div>
+    
+    <div class="status">
+      <span id="connection">Connecting...</span>
+    </div>
+  </div>
+  
+  <script>
+    // Elements
+    const logsContainer = document.getElementById('logs');
+    const clearBtn = document.getElementById('clearBtn');
+    const pauseBtn = document.getElementById('pauseBtn');
+    const scrollBtn = document.getElementById('scrollBtn');
+    const connectionStatus = document.getElementById('connection');
+    
+    // State
+    let isPaused = false;
+    let autoScroll = true;
+    
+    // Initialize UI state
+    updateButtons();
+    
+    // Set up event handlers
+    clearBtn.addEventListener('click', clearLogs);
+    pauseBtn.addEventListener('click', togglePause);
+    scrollBtn.addEventListener('click', toggleScroll);
+    
+    // Functions
+    function clearLogs() {
+      logsContainer.innerHTML = '';
+    }
+    
+    function togglePause() {
+      isPaused = !isPaused;
+      updateButtons();
+    }
+    
+    function toggleScroll() {
+      autoScroll = !autoScroll;
+      updateButtons();
+    }
+    
+    function updateButtons() {
+      pauseBtn.textContent = isPaused ? 'Resume' : 'Pause';
+      pauseBtn.style.backgroundColor = isPaused ? '#e74c3c' : '';
+      
+      scrollBtn.textContent = `Auto-scroll: ${autoScroll ? 'ON' : 'OFF'}`;
+      scrollBtn.style.backgroundColor = autoScroll ? '#2ecc71' : '';
+    }
+
+    function onLogLineReceived(event) {
+      if (isPaused) return;
+
+      const log = document.createElement('span');
+      log.className = 'log-line';
+      log.innerText = event.data;
+      logsContainer.appendChild(log);
+
+      if (autoScroll) {
+        logsContainer.scrollTop = logsContainer.scrollHeight;
+      }
+    }
+
+    function onConnected() {
+      connectionStatus.textContent = 'Connected';
+      connectionStatus.style.color = '#2ecc71';
+    }
+
+    function onDisconnected() {
+      connectionStatus.textContent = 'Disconnected';
+      connectionStatus.style.color = '#e74c3c';
+    }
+
+    function subscribeToSSE() {
+      const source = new EventSource('/log-events');
+      source.onopen = onConnected;
+      source.onerror = onDisconnected;
+      source.addEventListener('log-line', onLogLineReceived, false);
+    }
+
+    // Subscribe to Server-Sent Events
+    if (!!window.EventSource) {
+      subscribeToSSE();
+    } else {
+      logsContainer.innerHTML = '<span class="log-line">Your browser does not support Server-Sent Events.</span>';
+    }
+  </script>
+</body>
+</html>

--- a/components/net-logging/net_logging.c
+++ b/components/net-logging/net_logging.c
@@ -127,7 +127,7 @@ esp_err_t sse_logging_init(unsigned long port, int16_t enableStdout) {
 	xRingBufferTrans = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
 	configASSERT( xRingBufferTrans );
 #else
-	printf("start HTTP Server Sent Events logging(xMessageBuffer): SSE server listening on port=%ld\n", port);
+	printf("start HTTP Server Sent Events logging(xMessageBuffer): SSE server starting on port=%ld\n", port);
 	// Create MessageBuffer
 	xMessageBufferTrans = xMessageBufferCreate(xBufferSizeBytes);
 	configASSERT( xMessageBufferTrans );

--- a/components/net-logging/net_logging.c
+++ b/components/net-logging/net_logging.c
@@ -117,6 +117,38 @@ esp_err_t tcp_logging_init(char *ipaddr, unsigned long port, int16_t enableStdou
 	return ESP_OK;
 }
 
+void sse_server(void *pvParameters);
+
+esp_err_t sse_logging_init(unsigned long port, int16_t enableStdout) {
+
+#if CONFIG_USE_RINGBUFFER
+	printf("start HTTP Server Sent Events logging(xRingBuffer): SSE server listening on port=%ld\n", port);
+	// Create RineBuffer
+	xRingBufferTrans = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
+	configASSERT( xRingBufferTrans );
+#else
+	printf("start HTTP Server Sent Events logging(xMessageBuffer): SSE server listening on port=%ld\n", port);
+	// Create MessageBuffer
+	xMessageBufferTrans = xMessageBufferCreate(xBufferSizeBytes);
+	configASSERT( xMessageBufferTrans );
+#endif
+
+	// Start SSE Server
+	PARAMETER_t param;
+	param.port = port;
+	param.taskHandle = xTaskGetCurrentTaskHandle();
+	xTaskCreate(sse_server, "HTTP SSE", 1024*6, (void *)&param, 2, NULL);
+
+	// Wait for ready to receive notify
+	ulTaskNotifyTake( pdTRUE, portMAX_DELAY );
+	//printf("ulTaskNotifyTake\n");
+
+	// Set function used to output log entries.
+	writeToStdout = enableStdout;
+	esp_log_set_vprintf(logging_vprintf);
+	return ESP_OK;
+}
+
 void mqtt_pub(void *pvParameters);
 
 esp_err_t mqtt_logging_init(char *url, char *topic, int16_t enableStdout) {

--- a/components/net-logging/net_logging.h
+++ b/components/net-logging/net_logging.h
@@ -27,6 +27,7 @@ esp_err_t udp_logging_init(char *ipaddr, unsigned long port, int16_t enableStdou
 esp_err_t tcp_logging_init(char *ipaddr, unsigned long port, int16_t enableStdout);
 esp_err_t mqtt_logging_init(char *url, char *topic, int16_t enableStdout);
 esp_err_t http_logging_init(char *url, int16_t enableStdout);
+esp_err_t sse_logging_init(unsigned long port, int16_t enableStdout);
 
 #ifdef __cplusplus
 }

--- a/components/net-logging/sse_server.c
+++ b/components/net-logging/sse_server.c
@@ -1,0 +1,203 @@
+/*
+  SSE server
+
+  This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+  Unless required by applicable law or agreed to in writing, this
+  software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h> // for close()
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h" // for vTaskDelete()
+#if CONFIG_USE_RINGBUFFER
+#include "freertos/ringbuf.h"
+#else
+#include "freertos/message_buffer.h"
+#endif
+#include "esp_system.h"
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+
+#include "net_logging.h"
+
+// File content buffer for sse.html
+extern const unsigned char sse_html_start[] asm("_binary_sse_html_start");
+extern const unsigned char sse_html_end[] asm("_binary_sse_html_end");
+
+#if CONFIG_USE_RINGBUFFER
+extern RingbufHandle_t xRingBufferTrans;
+#else
+extern MessageBufferHandle_t xMessageBufferTrans;
+#endif
+
+void serve_client(int client_sock) {
+  const size_t sse_html_size = sse_html_end - sse_html_start;
+
+  // Receive HTTP request
+  char rx_buffer[1024];
+  int rx_len = recv(client_sock, rx_buffer, sizeof(rx_buffer) - 1, 0);
+  if (rx_len <= 0) {
+    // printf("Connection closed or error\n");
+    close(client_sock);
+    return;
+  }
+
+  // Null-terminate received data
+  rx_buffer[rx_len] = 0;
+
+  // Check if the request is for the root path (/)
+  if (strstr(rx_buffer, "GET / HTTP") != NULL) {
+    // Serve the HTML file
+    // printf("Serving HTML file\n");
+
+    // Prepare HTTP response
+    char resp_header[256];
+    snprintf(resp_header, sizeof(resp_header),
+             "HTTP/1.1 200 OK\r\n"
+             "Content-Type: text/html\r\n"
+             "Content-Length: %d\r\n"
+             "Connection: close\r\n"
+             "\r\n",
+             sse_html_size);
+
+    // Send header
+    send(client_sock, resp_header, strlen(resp_header), 0);
+
+    // Send file content
+    send(client_sock, sse_html_start, sse_html_size, 0);
+  }
+  // Check if the request is for the SSE endpoint
+  else if (strstr(rx_buffer, "GET /log-events HTTP") != NULL) {
+    // Set up SSE connection
+    // printf("SSE connection established\n");
+
+    // Send SSE headers
+    const char *sse_headers = "HTTP/1.1 200 OK\r\n"
+                              "Content-Type: text/event-stream\r\n"
+                              "Cache-Control: no-cache\r\n"
+                              "Connection: keep-alive\r\n"
+                              "Access-Control-Allow-Origin: *\r\n"
+                              "\r\n";
+
+    send(client_sock, sse_headers, strlen(sse_headers), 0);
+
+    // Keep connection open and send SSE events
+    while (1) {
+      #if CONFIG_USE_RINGBUFFER
+      size_t received;
+      char *buffer = (char *)xRingbufferReceive(xRingBufferTrans, &received, portMAX_DELAY);
+      #else
+      char buffer[xItemSize];
+      size_t received = xMessageBufferReceive(xMessageBufferTrans, buffer, sizeof(buffer), portMAX_DELAY);
+      #endif
+
+      if (received > 0) {
+        // Format the buffer content as an SSE event
+        char sse_event[512];
+        snprintf(sse_event, sizeof(sse_event), "event: log-line\ndata: %.*s\n\n", (int)received, buffer);
+
+        #if CONFIG_USE_RINGBUFFER
+        vRingbufferReturnItem(xRingBufferTrans, (void *)buffer);
+        #endif
+
+        // Send the event
+        int ret = send(client_sock, sse_event, strlen(sse_event), 0);
+        if (ret < 0) {
+          // printf("Error sending SSE event: errno %d\n", errno);
+          break;
+        }
+      } else {
+        break;
+      }
+    }
+  } else {
+    // Not found response for other paths
+    const char *not_found = "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: text/plain\r\n"
+    "Content-Length: 9\r\n"
+    "Connection: close\r\n"
+    "\r\n"
+    "Not Found";
+
+    send(client_sock, not_found, strlen(not_found), 0);
+  }
+
+  // Close connection
+  close(client_sock);
+}
+
+void sse_server(void *pvParameters) {
+  PARAMETER_t *task_parameter = pvParameters;
+  PARAMETER_t param;
+  memcpy((char *)&param, task_parameter, sizeof(PARAMETER_t));
+  printf("Start:param.port=%d\n", param.port);
+
+  int addr_family = AF_INET;
+  int ip_protocol = IPPROTO_IP;
+
+  // Create a server socket instead of a client one
+  struct sockaddr_in server_addr;
+  server_addr.sin_addr.s_addr = htonl(INADDR_ANY); // Listen on all interfaces
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(param.port);
+
+  int server_sock = socket(addr_family, SOCK_STREAM, ip_protocol);
+  if (server_sock < 0) {
+    printf("Unable to create socket: errno %d\n", errno);
+    vTaskDelete(NULL);
+  }
+
+  // Set socket option to reuse address
+  int opt = 1;
+  setsockopt(server_sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  // Bind socket to address
+  int err =
+      bind(server_sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+  if (err != 0) {
+    printf("Socket unable to bind: errno %d\n", errno);
+    close(server_sock);
+    vTaskDelete(NULL);
+  }
+
+  // Start listening
+  err = listen(server_sock, 5);
+  if (err != 0) {
+    printf("Error listening on socket: errno %d\n", errno);
+    close(server_sock);
+    vTaskDelete(NULL);
+  }
+
+  printf("SSE Server listening on port %d\n", param.port);
+
+  // Send ready to receive notify
+  xTaskNotifyGive(param.taskHandle);
+
+  // Main server loop
+  while (1) {
+    struct sockaddr_in client_addr;
+    socklen_t client_addr_len = sizeof(client_addr);
+    int client_sock = accept(server_sock, (struct sockaddr *)&client_addr, &client_addr_len);
+
+    if (client_sock < 0) {
+      // printf("Unable to accept connection: errno %d\n", errno);
+      continue;
+    }
+
+    serve_client(client_sock);
+  }
+
+  if (server_sock != -1) {
+    shutdown(server_sock, 0);
+    close(server_sock);
+  }
+  vTaskDelete(NULL);
+}


### PR DESCRIPTION
Hi there,

Thank you for open sourcing this, it has been useful !

Just wanted to contribute by adding log viewing over SSE.

This supports my use case of viewing logs from an ESP32 while freeing up all UARTs for other things, and without having to setup and maintain a logs sink server.

This is far from a perfect implementation, but so far, it has been working OK for a single client connection viewing logs

The usage is similar to other impls:
- include the header file:
```c
#include "net_logging.h"
```
- initialize the server at the point in the code from which logs should be redirected:
```c
unsigned long port = 8080;
int16_t enableStdout = 0;
sse_logging_init(port, enableStdout);
```
I remain open to suggestions.

Thanks