### PR TITLE
change defines that conflict with variable names in "freetos/ringbuf.h"

### DIFF
--- a/components/net-logging/http_client.c
+++ b/components/net-logging/http_client.c
@@ -195,7 +195,7 @@ void http_client(void *pvParameters)
 		char *buffer = (char *)xRingbufferReceive(xRingBufferHTTP, &received, portMAX_DELAY);
 		//printf("xRingBufferReceive received=%d\n", received);
 #else
-		char buffer[xItemSize];
+		char buffer[NET_LOGGING_XITEMSIZE];
 		size_t received = xMessageBufferReceive(xMessageBufferHTTP, buffer, sizeof(buffer), portMAX_DELAY);
 		//printf("xMessageBufferReceive received=%d\n", received);
 #endif

--- a/components/net-logging/mqtt_pub.c
+++ b/components/net-logging/mqtt_pub.c
@@ -139,7 +139,7 @@ void mqtt_pub(void *pvParameters)
 		char *buffer = (char *)xRingbufferReceive(xRingBufferMQTT, &received, portMAX_DELAY);
 		//printf("xRingBufferReceive received=%d\n", received);
 #else
-		char buffer[xItemSize];
+		char buffer[NET_LOGGING_XITEMSIZE];
 		size_t received = xMessageBufferReceive(xMessageBufferMQTT, buffer, sizeof(buffer), portMAX_DELAY);
 		//printf("xMessageBufferReceive received=%d\n", received);
 #endif

--- a/components/net-logging/net_logging.c
+++ b/components/net-logging/net_logging.c
@@ -34,20 +34,20 @@ bool writeToStdout;
 
 int logging_vprintf( const char *fmt, va_list l ) {
 	// Convert according to format
-	char buffer[xItemSize];
+	char buffer[NET_LOGGING_XITEMSIZE];
 	//int buffer_len = vsprintf(buffer, fmt, l);
-	int buffer_len = vsnprintf(buffer, xItemSize, fmt, l);
+	int buffer_len = vsnprintf(buffer, NET_LOGGING_XITEMSIZE, fmt, l);
 
 #if 0
-	xItemSize > buffer_len
+	NET_LOGGING_XITEMSIZE > buffer_len
 	I (307) MAIN: xItemSize=20 buffer_len=11 strlen(buffer)=11
 	I (307) MAIN: buffer=[76 61 6c 75 65 3a 20 31 30 30 0a]
 
-	xItemSize = buffer_len
+	NET_LOGGING_XITEMSIZE = buffer_len
 	I (307) MAIN: xItemSize=11 buffer_len=11 strlen(buffer)=10
 	I (307) MAIN: buffer=[76 61 6c 75 65 3a 20 31 30 30 00]
 
-	xItemSize < buffer_len
+	NET_LOGGING_XITEMSIZE < buffer_len
 	I (307) MAIN: xItemSize=10 buffer_len=11 strlen(buffer)=9
 	I (307) MAIN: buffer=[76 61 6c 75 65 3a 20 31 30 00 00]
 #endif
@@ -120,12 +120,12 @@ esp_err_t udp_logging_init(const char *ipaddr, unsigned long port, int16_t enabl
 #if CONFIG_NET_LOGGING_USE_RINGBUFFER
 	printf("start udp logging(xRingBuffer): ipaddr=[%s] port=%ld\n", ipaddr, port);
 	// Create RineBuffer
-	xRingBufferUDP = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
+	xRingBufferUDP = xRingbufferCreate(NET_LOGGING_XBUFFERSIZEBYTES, RINGBUF_TYPE_NOSPLIT);
 	configASSERT( xRingBufferUDP );
 #else
 	printf("start udp logging(xMessageBuffer): ipaddr=[%s] port=%ld\n", ipaddr, port);
 	// Create MessageBuffer
-	xMessageBufferUDP = xMessageBufferCreate(xBufferSizeBytes);
+	xMessageBufferUDP = xMessageBufferCreate(NET_LOGGING_XBUFFERSIZEBYTES);
 	configASSERT( xMessageBufferUDP );
 #endif
 
@@ -163,12 +163,12 @@ esp_err_t tcp_logging_init(const char *ipaddr, unsigned long port, int16_t enabl
 #if CONFIG_NET_LOGGING_USE_RINGBUFFER
 	printf("start tcp logging(xRingBuffer): ipaddr=[%s] port=%ld\n", ipaddr, port);
 	// Create RineBuffer
-	xRingBufferTCP = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
+	xRingBufferTCP = xRingbufferCreate(NET_LOGGING_XBUFFERSIZEBYTES, RINGBUF_TYPE_NOSPLIT);
 	configASSERT( xRingBufferTCP );
 #else
 	printf("start tcp logging(xMessageBuffer): ipaddr=[%s] port=%ld\n", ipaddr, port);
 	// Create MessageBuffer
-	xMessageBufferTCP = xMessageBufferCreate(xBufferSizeBytes);
+	xMessageBufferTCP = xMessageBufferCreate(NET_LOGGING_XBUFFERSIZEBYTES);
 	configASSERT( xMessageBufferTCP );
 #endif
 
@@ -206,12 +206,12 @@ esp_err_t sse_logging_init(unsigned long port, int16_t enableStdout) {
 #if CONFIG_NET_LOGGING_USE_RINGBUFFER
 	printf("start HTTP Server Sent Events logging(xRingBuffer): SSE server listening on port=%ld\n", port);
 	// Create RineBuffer
-	xRingBufferSSE = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
+	xRingBufferSSE = xRingbufferCreate(NET_LOGGING_XBUFFERSIZEBYTES, RINGBUF_TYPE_NOSPLIT);
 	configASSERT( xRingBufferSSE );
 #else
 	printf("start HTTP Server Sent Events logging(xMessageBuffer): SSE server starting on port=%ld\n", port);
 	// Create MessageBuffer
-	xMessageBufferSSE = xMessageBufferCreate(xBufferSizeBytes);
+	xMessageBufferSSE = xMessageBufferCreate(NET_LOGGING_XBUFFERSIZEBYTES);
 	configASSERT( xMessageBufferSSE );
 #endif
 
@@ -248,12 +248,12 @@ esp_err_t mqtt_logging_init(const char *url, char *topic, int16_t enableStdout) 
 #if CONFIG_NET_LOGGING_USE_RINGBUFFER
 	printf("start mqtt logging(xRingBuffer): url=[%s] topic=[%s]\n", url, topic);
 	// Create RineBuffer
-	xRingBufferMQTT = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
+	xRingBufferMQTT = xRingbufferCreate(NET_LOGGING_XBUFFERSIZEBYTES, RINGBUF_TYPE_NOSPLIT);
 	configASSERT( xRingBufferMQTT );
 #else
 	printf("start mqtt logging(xMessageBuffer): url=[%s] topic=[%s]\n", url, topic);
 	// Create MessageBuffer
-	xMessageBufferMQTT = xMessageBufferCreate(xBufferSizeBytes);
+	xMessageBufferMQTT = xMessageBufferCreate(NET_LOGGING_XBUFFERSIZEBYTES);
 	configASSERT( xMessageBufferMQTT );
 #endif
 
@@ -291,12 +291,12 @@ esp_err_t http_logging_init(const char *url, int16_t enableStdout) {
 #if CONFIG_NET_LOGGING_USE_RINGBUFFER
 	printf("start http logging(xRingBuffer): url=[%s]\n", url);
 	// Create RineBuffer
-	xRingBufferHTTP = xRingbufferCreate(xBufferSizeBytes, RINGBUF_TYPE_NOSPLIT);
+	xRingBufferHTTP = xRingbufferCreate(NET_LOGGING_XBUFFERSIZEBYTES, RINGBUF_TYPE_NOSPLIT);
 	configASSERT( xRingBufferHTTP );
 #else
 	printf("start http logging(xMessageBuffer): url=[%s]\n", url);
 	// Create MessageBuffer
-	xMessageBufferHTTP = xMessageBufferCreate(xBufferSizeBytes);
+	xMessageBufferHTTP = xMessageBufferCreate(NET_LOGGING_XBUFFERSIZEBYTES);
 	configASSERT( xMessageBufferHTTP );
 #endif
 

--- a/components/net-logging/net_logging.h
+++ b/components/net-logging/net_logging.h
@@ -17,9 +17,9 @@ typedef struct {
 } PARAMETER_t;
 
 // The total number of bytes (not messages) the message buffer will be able to hold at any one time.
-#define xBufferSizeBytes 1024
+#define NET_LOGGING_XBUFFERSIZEBYTES 1024
 // The size, in bytes, required to hold each item in the message,
-#define xItemSize 256
+#define NET_LOGGING_XITEMSIZE 256
 
 
 int logging_vprintf( const char *fmt, va_list l );

--- a/components/net-logging/sse_server.c
+++ b/components/net-logging/sse_server.c
@@ -104,7 +104,7 @@ void serve_client(void *pvParameters) {
       size_t received;
       char *buffer = (char *)xRingbufferReceive(xRingBufferSSE, &received, pdMS_TO_TICKS(10));
       #else
-      char buffer[xItemSize];
+      char buffer[NET_LOGGING_XITEMSIZE];
       size_t received = xMessageBufferReceive(xMessageBufferSSE, buffer, sizeof(buffer), pdMS_TO_TICKS(10));
       #endif
 

--- a/components/net-logging/tcp_client.c
+++ b/components/net-logging/tcp_client.c
@@ -86,7 +86,7 @@ void tcp_client(void *pvParameters)
         char *buffer = (char *)xRingbufferReceive(xRingBufferTCP, &received, portMAX_DELAY);
         //printf("xRingBufferReceive received=%d\n", received);
 #else
-		char buffer[xItemSize];
+		char buffer[NET_LOGGING_XITEMSIZE];
 		size_t received = xMessageBufferReceive(xMessageBufferTCP, buffer, sizeof(buffer), portMAX_DELAY);
 		//printf("xMessageBufferReceive received=%d\n", received);
 #endif

--- a/components/net-logging/udp_client.c
+++ b/components/net-logging/udp_client.c
@@ -70,7 +70,7 @@ void udp_client(void *pvParameters) {
 		char *buffer = (char *)xRingbufferReceive(xRingBufferUDP, &received, portMAX_DELAY);
 		//printf("xRingBufferReceive received=%d\n", received);
 #else
-		char buffer[xItemSize];
+		char buffer[NET_LOGGING_XITEMSIZE];
 		size_t received = xMessageBufferReceive(xMessageBufferUDP, buffer, sizeof(buffer), portMAX_DELAY);
 		//printf("xMessageBufferReceive received=%d\n", received);
 #endif


### PR DESCRIPTION
changed defines that conflict with variable names in "freetos/ringbuf.h"

if #include "net_logging.h" in a project is before another #include "xxxxxxx" which uses "freetos/ringbuf.h" the build process fails because the variable xItemSize passed as a parameter to some ringbuf.h functions is defined as a constant of 256
(Shouldn't defines be unique and all upper case)